### PR TITLE
feat: add data availability challenge event to vote pool

### DIFF
--- a/votepool/event_type.go
+++ b/votepool/event_type.go
@@ -9,4 +9,7 @@ const (
 
 	// FromBscCrossChainEvent defines the type of cross chain events from BSC to the current chain.
 	FromBscCrossChainEvent EventType = 2
+
+	// DataChallengeEvent defines the type of events for data availability challenges.
+	DataAvailabilityChallengeEvent EventType = 3
 )

--- a/votepool/pool.go
+++ b/votepool/pool.go
@@ -137,8 +137,7 @@ type Pool struct {
 
 // NewVotePool creates a Pool, the init validators should be supplied.
 func NewVotePool(logger log.Logger, validators []*types.Validator, eventBus *types.EventBus) (*Pool, error) {
-	// only used for cross chain votes currently.
-	eventTypes := []EventType{ToBscCrossChainEvent, FromBscCrossChainEvent}
+	eventTypes := []EventType{ToBscCrossChainEvent, FromBscCrossChainEvent, DataAvailabilityChallengeEvent}
 
 	ticker := time.NewTicker(pruneVoteInterval)
 	stores := make(map[EventType]*voteStore, len(eventTypes))

--- a/votepool/vote.go
+++ b/votepool/vote.go
@@ -46,7 +46,9 @@ func (v *Vote) ValidateBasic() error {
 	if len(v.EventHash) != eventHashLen {
 		return errors.New("invalid event hash")
 	}
-	if v.EventType != ToBscCrossChainEvent && v.EventType != FromBscCrossChainEvent {
+	if v.EventType != ToBscCrossChainEvent &&
+		v.EventType != FromBscCrossChainEvent &&
+		v.EventType != DataAvailabilityChallengeEvent {
 		return errors.New("invalid event type")
 	}
 	if len(v.PubKey) != pubKeyLen {

--- a/votepool/vote_test.go
+++ b/votepool/vote_test.go
@@ -36,7 +36,7 @@ func TestVote_ValidateBasic(t *testing.T) {
 			vote: Vote{
 				PubKey:    pubKey,
 				Signature: sign,
-				EventType: 3,
+				EventType: 10,
 				EventHash: eventHash,
 				expireAt:  time.Time{},
 			},


### PR DESCRIPTION
## Description

This pr will add `DataAvailabilityChallengeEvent` event type to vote pool. This event type will be used in data availability challenge, to collect challenge votes from different validators.

## Rational
To support data availability challenge.

## Example
NA

## Changes
- add `DataAvailabilityChallengeEvent` event type
