### PR TITLE
release: prepare for release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.0.4
+
+This is a maintenance release.
+
+* [\#30](https://github.com/bnb-chain/greenfield-tendermint/pull/30) chore: remove challenger address in tendermint
+
 ## v0.0.3
 
 This is a maintenance release.


### PR DESCRIPTION
### Description

This pr prepares for the release of v0.0.4.

Changes

* [\#30](https://github.com/bnb-chain/greenfield-tendermint/pull/30) chore: remove challenger address in tendermint

### Rationale

for release

### Example
NA

### Changes

Notable changes:
* CHANGELOG
